### PR TITLE
Update content URL to explicitely discard cache (at least for the page)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This page collects information around CTA WAVE Test Content.
 
-CTA WAVE Test Content is hosted here: https://dash.akamaized.net/WAVE/index.html
+CTA WAVE Test Content is hosted here: https://dash.akamaized.net/WAVE/index.html?cache=clear
 
 
 How to add content:


### PR DESCRIPTION
cf #7:

I think that was answered by Will Law in an email: "The account you are using is [a] test asset storage account, It is designed for very high volume delivery of video assets that don’t change very often (like test assets). [...] if you don’t supply the query arg, then it will give you the cached version. Bypassing the cache with the query arg does not then pull that object in to cache ;("

So this doesn't actually solve the whole issue.