### PR TITLE
update db to use dash-large-files.akamaized.net

### DIFF
--- a/database.json
+++ b/database.json
@@ -15,8 +15,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t1/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t1/2023-09-01/t1.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t1/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t1/2023-09-01/t1.zip"
         },
         "cfhd_sets/12.5_25_50/t2/2023-09-01/": {
             "source": "croatia_L1_1920x1080@25_30 version 4 (2023-02-13)",
@@ -33,8 +33,8 @@
             "hasSEI": false,
             "hasVUITiming": true,
             "visualSampleEntry": "avc3",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t2/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t2/2023-09-01/t2.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t2/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t2/2023-09-01/t2.zip"
         },
         "cfhd_sets/12.5_25_50/t3/2023-09-01/": {
             "source": "croatia_L1_1920x1080@25_30 version 4 (2023-02-13)",
@@ -51,8 +51,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1+3",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t3/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t3/2023-09-01/t3.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t3/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t3/2023-09-01/t3.zip"
         },
         "cfhd_sets/12.5_25_50/t10/2023-09-01/": {
             "source": "croatia_L1_1920x1080@25_30 version 4 (2023-02-13)",
@@ -69,8 +69,8 @@
             "hasSEI": false,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t10/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t10/2023-09-01/t10.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t10/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t10/2023-09-01/t10.zip"
         },
         "cfhd_sets/12.5_25_50/t11/2023-09-01/": {
             "source": "croatia_L1_1920x1080@25_30 version 4 (2023-02-13)",
@@ -87,8 +87,8 @@
             "hasSEI": true,
             "hasVUITiming": true,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t11/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t11/2023-09-01/t11.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t11/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t11/2023-09-01/t11.zip"
         },
         "cfhd_sets/12.5_25_50/t12/2023-09-01/": {
             "source": "croatia_L1_1920x1080@25_30 version 4 (2023-02-13)",
@@ -105,8 +105,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc3",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t12/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t12/2023-09-01/t12.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t12/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t12/2023-09-01/t12.zip"
         },
         "cfhd_sets/12.5_25_50/t13/2023-09-01/": {
             "source": "croatia_L1_1920x1080@25_30 version 4 (2023-02-13)",
@@ -123,8 +123,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1+3",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t13/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t13/2023-09-01/t13.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t13/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t13/2023-09-01/t13.zip"
         },
         "cfhd_sets/12.5_25_50/t14/2023-09-01/": {
             "source": "croatia_L1_1920x1080@25_30 version 4 (2023-02-13)",
@@ -141,8 +141,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t14/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t14/2023-09-01/t14.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t14/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t14/2023-09-01/t14.zip"
         },
         "cfhd_sets/12.5_25_50/t15/2023-09-01/": {
             "source": "croatia_L1_1920x1080@25_30 version 4 (2023-02-13)",
@@ -159,8 +159,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t15/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t15/2023-09-01/t15.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t15/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t15/2023-09-01/t15.zip"
         },
         "cfhd_sets/12.5_25_50/t16/2023-09-01/": {
             "source": "croatia_L1_1920x1080@25_30 version 4 (2023-02-13)",
@@ -177,8 +177,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t16/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t16/2023-09-01/t16.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t16/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t16/2023-09-01/t16.zip"
         },
         "cfhd_sets/12.5_25_50/t17/2023-09-01/": {
             "source": "croatia_L1_1920x1080@25_30 version 4 (2023-02-13)",
@@ -195,8 +195,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t17/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t17/2023-09-01/t17.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t17/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t17/2023-09-01/t17.zip"
         },
         "cfhd_sets/12.5_25_50/t19/2023-09-01/": {
             "source": "croatia_L1_1920x1080@25_60 version 4 (2023-02-13)",
@@ -213,8 +213,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t19/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t19/2023-09-01/t19.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t19/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t19/2023-09-01/t19.zip"
         },
         "cfhd_sets/12.5_25_50/t21/2023-09-01/": {
             "source": "croatia_K1_1600x900@25_60 version 4 (2023-02-13)",
@@ -231,8 +231,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t21/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t21/2023-09-01/t21.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t21/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t21/2023-09-01/t21.zip"
         },
         "cfhd_sets/12.5_25_50/t22/2023-09-01/": {
             "source": "croatia_J1_1280x720@25_60 version 4 (2023-02-13)",
@@ -249,8 +249,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t22/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t22/2023-09-01/t22.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t22/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t22/2023-09-01/t22.zip"
         },
         "cfhd_sets/12.5_25_50/t23/2023-09-01/": {
             "source": "croatia_J1_1280x720@50_60 version 4 (2023-02-13)",
@@ -267,8 +267,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t23/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t23/2023-09-01/t23.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t23/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t23/2023-09-01/t23.zip"
         },
         "cfhd_sets/12.5_25_50/t24/2023-09-01/": {
             "source": "croatia_I1_1024x576@25_60 version 4 (2023-02-13)",
@@ -285,8 +285,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t24/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t24/2023-09-01/t24.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t24/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t24/2023-09-01/t24.zip"
         },
         "cfhd_sets/12.5_25_50/t25/2023-09-01/": {
             "source": "croatia_I2_1024x576@25_60 version 4 (2023-02-13)",
@@ -303,8 +303,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t25/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t25/2023-09-01/t25.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t25/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t25/2023-09-01/t25.zip"
         },
         "cfhd_sets/12.5_25_50/t26/2023-09-01/": {
             "source": "croatia_H1_960x540@25_60 version 4 (2023-02-13)",
@@ -321,8 +321,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t26/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t26/2023-09-01/t26.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t26/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t26/2023-09-01/t26.zip"
         },
         "cfhd_sets/12.5_25_50/t27/2023-09-01/": {
             "source": "croatia_G1_852x480@25_60 version 4 (2023-02-13)",
@@ -339,8 +339,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t27/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t27/2023-09-01/t27.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t27/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t27/2023-09-01/t27.zip"
         },
         "cfhd_sets/12.5_25_50/t28/2023-09-01/": {
             "source": "croatia_F1_768x432@25_60 version 4 (2023-02-13)",
@@ -357,8 +357,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t28/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t28/2023-09-01/t28.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t28/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t28/2023-09-01/t28.zip"
         },
         "cfhd_sets/12.5_25_50/t29/2023-09-01/": {
             "source": "croatia_E1_720x404@25_60 version 4 (2023-02-13)",
@@ -375,8 +375,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t29/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t29/2023-09-01/t29.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t29/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t29/2023-09-01/t29.zip"
         },
         "cfhd_sets/12.5_25_50/t30/2023-09-01/": {
             "source": "croatia_D1_704x396@25_60 version 4 (2023-02-13)",
@@ -393,8 +393,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t30/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t30/2023-09-01/t30.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t30/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t30/2023-09-01/t30.zip"
         },
         "cfhd_sets/12.5_25_50/t31/2023-09-01/": {
             "source": "croatia_C1_640x360@25_60 version 4 (2023-02-13)",
@@ -411,8 +411,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t31/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t31/2023-09-01/t31.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t31/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t31/2023-09-01/t31.zip"
         },
         "cfhd_sets/12.5_25_50/t32/2023-09-01/": {
             "source": "croatia_B1_512x288@25_60 version 4 (2023-02-13)",
@@ -429,8 +429,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t32/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t32/2023-09-01/t32.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t32/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t32/2023-09-01/t32.zip"
         },
         "cfhd_sets/12.5_25_50/t33/2023-09-01/": {
             "source": "croatia_A1_480x270@25_60 version 4 (2023-02-13)",
@@ -447,8 +447,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t33/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t33/2023-09-01/t33.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t33/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t33/2023-09-01/t33.zip"
         },
         "cfhd_sets/12.5_25_50/t34/2023-09-01/": {
             "source": "croatia_A1_480x270@12.5_60 version 4 (2023-02-13)",
@@ -465,8 +465,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t34/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t34/2023-09-01/t34.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t34/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t34/2023-09-01/t34.zip"
         },
         "switching_sets/12.5_25_50/ss1/2023-10-05": {
             "source": "CTA WAVE",
@@ -531,8 +531,8 @@
             "hasSEI": false,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/switching_sets/12.5_25_50/ss1/2023-10-05/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/switching_sets/12.5_25_50/ss1/2023-10-05/ss1.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/switching_sets/12.5_25_50/ss1/2023-10-05/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/switching_sets/12.5_25_50/ss1/2023-10-05/ss1.zip"
         },
         "cfhd_sets/12.5_25_50/tLD/2023-09-01/": {
             "source": "croatia_LD1_1920x1080@25_7200 version 4 (2023-02-15)",
@@ -549,7 +549,7 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/tLD/2023-09-01/stream.mpd",
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/tLD/2023-09-01/stream.mpd",
             "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/tLD/2023-09-01/tLD.zip"
         },
         "cfhd_sets/15_30_60/t1/2023-09-01/": {
@@ -567,8 +567,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t1/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t1/2023-09-01/t1.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t1/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t1/2023-09-01/t1.zip"
         },
         "cfhd_sets/15_30_60/t2/2023-09-01/": {
             "source": "tos_L1_1920x1080@30_30 version 4 (2023-02-13)",
@@ -585,8 +585,8 @@
             "hasSEI": false,
             "hasVUITiming": true,
             "visualSampleEntry": "avc3",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t2/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t2/2023-09-01/t2.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t2/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t2/2023-09-01/t2.zip"
         },
         "cfhd_sets/15_30_60/t3/2023-09-01/": {
             "source": "tos_L1_1920x1080@30_30 version 4 (2023-02-13)",
@@ -603,8 +603,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1+3",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t3/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t3/2023-09-01/t3.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t3/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t3/2023-09-01/t3.zip"
         },
         "cfhd_sets/15_30_60/t10/2023-09-01/": {
             "source": "tos_L1_1920x1080@30_30 version 4 (2023-02-13)",
@@ -621,8 +621,8 @@
             "hasSEI": false,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t10/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t10/2023-09-01/t10.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t10/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t10/2023-09-01/t10.zip"
         },
         "cfhd_sets/15_30_60/t11/2023-09-01/": {
             "source": "tos_L1_1920x1080@30_30 version 4 (2023-02-13)",
@@ -639,8 +639,8 @@
             "hasSEI": true,
             "hasVUITiming": true,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t11/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t11/2023-09-01/t11.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t11/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t11/2023-09-01/t11.zip"
         },
         "cfhd_sets/15_30_60/t12/2023-09-01/": {
             "source": "tos_L1_1920x1080@30_30 version 4 (2023-02-13)",
@@ -657,8 +657,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc3",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t12/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t12/2023-09-01/t12.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t12/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t12/2023-09-01/t12.zip"
         },
         "cfhd_sets/15_30_60/t13/2023-09-01/": {
             "source": "tos_L1_1920x1080@30_30 version 4 (2023-02-13)",
@@ -675,8 +675,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1+3",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t13/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t13/2023-09-01/t13.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t13/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t13/2023-09-01/t13.zip"
         },
         "cfhd_sets/15_30_60/t14/2023-09-01/": {
             "source": "tos_L1_1920x1080@30_30 version 4 (2023-02-13)",
@@ -693,8 +693,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t14/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t14/2023-09-01/t14.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t14/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t14/2023-09-01/t14.zip"
         },
         "cfhd_sets/15_30_60/t15/2023-09-01/": {
             "source": "tos_L1_1920x1080@30_30 version 4 (2023-02-13)",
@@ -711,8 +711,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t15/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t15/2023-09-01/t15.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t15/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t15/2023-09-01/t15.zip"
         },
         "cfhd_sets/15_30_60/t16/2023-09-01/": {
             "source": "tos_L1_1920x1080@30_30 version 4 (2023-02-13)",
@@ -729,8 +729,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t16/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t16/2023-09-01/t16.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t16/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t16/2023-09-01/t16.zip"
         },
         "cfhd_sets/15_30_60/t17/2023-09-01/": {
             "source": "tos_L1_1920x1080@30_30 version 4 (2023-02-13)",
@@ -747,8 +747,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t17/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t17/2023-09-01/t17.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t17/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t17/2023-09-01/t17.zip"
         },
         "cfhd_sets/15_30_60/t19/2023-09-01/": {
             "source": "tos_L1_1920x1080@30_60 version 4 (2023-02-13)",
@@ -765,8 +765,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t19/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t19/2023-09-01/t19.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t19/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t19/2023-09-01/t19.zip"
         },
         "cfhd_sets/15_30_60/t21/2023-09-01/": {
             "source": "tos_K1_1600x900@30_60 version 4 (2023-02-13)",
@@ -783,8 +783,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t21/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t21/2023-09-01/t21.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t21/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t21/2023-09-01/t21.zip"
         },
         "cfhd_sets/15_30_60/t22/2023-09-01/": {
             "source": "tos_J1_1280x720@30_60 version 4 (2023-02-13)",
@@ -801,8 +801,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t22/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t22/2023-09-01/t22.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t22/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t22/2023-09-01/t22.zip"
         },
         "cfhd_sets/15_30_60/t23/2023-09-01/": {
             "source": "tos_J1_1280x720@60_60 version 4 (2023-02-13)",
@@ -819,8 +819,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t23/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t23/2023-09-01/t23.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t23/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t23/2023-09-01/t23.zip"
         },
         "cfhd_sets/15_30_60/t24/2023-09-01/": {
             "source": "tos_I1_1024x576@30_60 version 4 (2023-02-13)",
@@ -837,8 +837,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t24/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t24/2023-09-01/t24.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t24/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t24/2023-09-01/t24.zip"
         },
         "cfhd_sets/15_30_60/t25/2023-09-01/": {
             "source": "tos_I2_1024x576@30_60 version 4 (2023-02-13)",
@@ -855,8 +855,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t25/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t25/2023-09-01/t25.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t25/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t25/2023-09-01/t25.zip"
         },
         "cfhd_sets/15_30_60/t26/2023-09-01/": {
             "source": "tos_H1_960x540@30_60 version 4 (2023-02-13)",
@@ -873,8 +873,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t26/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t26/2023-09-01/t26.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t26/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t26/2023-09-01/t26.zip"
         },
         "cfhd_sets/15_30_60/t27/2023-09-01/": {
             "source": "tos_G1_852x480@30_60 version 4 (2023-02-13)",
@@ -891,8 +891,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t27/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t27/2023-09-01/t27.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t27/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t27/2023-09-01/t27.zip"
         },
         "cfhd_sets/15_30_60/t28/2023-09-01/": {
             "source": "tos_F1_768x432@30_60 version 4 (2023-02-13)",
@@ -909,8 +909,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t28/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t28/2023-09-01/t28.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t28/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t28/2023-09-01/t28.zip"
         },
         "cfhd_sets/15_30_60/t29/2023-09-01/": {
             "source": "tos_E1_720x404@30_60 version 4 (2023-02-13)",
@@ -927,8 +927,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t29/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t29/2023-09-01/t29.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t29/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t29/2023-09-01/t29.zip"
         },
         "cfhd_sets/15_30_60/t30/2023-09-01/": {
             "source": "tos_D1_704x396@30_60 version 4 (2023-02-13)",
@@ -945,8 +945,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t30/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t30/2023-09-01/t30.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t30/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t30/2023-09-01/t30.zip"
         },
         "cfhd_sets/15_30_60/t31/2023-09-01/": {
             "source": "tos_C1_640x360@30_60 version 4 (2023-02-13)",
@@ -963,8 +963,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t31/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t31/2023-09-01/t31.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t31/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t31/2023-09-01/t31.zip"
         },
         "cfhd_sets/15_30_60/t32/2023-09-01/": {
             "source": "tos_B1_512x288@30_60 version 4 (2023-02-13)",
@@ -981,8 +981,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t32/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t32/2023-09-01/t32.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t32/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t32/2023-09-01/t32.zip"
         },
         "cfhd_sets/15_30_60/t33/2023-09-01/": {
             "source": "tos_A1_480x270@30_60 version 4 (2023-02-13)",
@@ -999,8 +999,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t33/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t33/2023-09-01/t33.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t33/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t33/2023-09-01/t33.zip"
         },
         "cfhd_sets/15_30_60/t34/2023-09-01/": {
             "source": "tos_A1_480x270@15_60 version 4 (2023-02-13)",
@@ -1017,8 +1017,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t34/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t34/2023-09-01/t34.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t34/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t34/2023-09-01/t34.zip"
         },
         "switching_sets/15_30_60/ss1/2023-10-05": {
             "source": "CTA WAVE",
@@ -1083,8 +1083,8 @@
             "hasSEI": false,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/switching_sets/15_30_60/ss1/2023-10-05/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/switching_sets/15_30_60/ss1/2023-10-05/ss1.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/switching_sets/15_30_60/ss1/2023-10-05/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/switching_sets/15_30_60/ss1/2023-10-05/ss1.zip"
         },
         "cfhd_sets/15_30_60/tLD/2023-09-01/": {
             "source": "tos_LD1_1920x1080@30_7200 version 4 (2023-02-13)",
@@ -1101,7 +1101,7 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/tLD/2023-09-01/stream.mpd",
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/tLD/2023-09-01/stream.mpd",
             "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/tLD/2023-09-01/tLD.zip"
         },
         "cfhd_sets/14.985_29.97_59.94/t1/2023-09-01/": {
@@ -1119,8 +1119,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t1/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t1/2023-09-01/t1.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t1/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t1/2023-09-01/t1.zip"
         },
         "cfhd_sets/14.985_29.97_59.94/t2/2023-09-01/": {
             "source": "tos_L1_1920x1080@29.97_30 version 4 (2023-02-13)",
@@ -1137,8 +1137,8 @@
             "hasSEI": false,
             "hasVUITiming": true,
             "visualSampleEntry": "avc3",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t2/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t2/2023-09-01/t2.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t2/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t2/2023-09-01/t2.zip"
         },
         "cfhd_sets/14.985_29.97_59.94/t3/2023-09-01/": {
             "source": "tos_L1_1920x1080@29.97_30 version 4 (2023-02-13)",
@@ -1155,8 +1155,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1+3",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t3/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t3/2023-09-01/t3.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t3/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t3/2023-09-01/t3.zip"
         },
         "cfhd_sets/14.985_29.97_59.94/t10/2023-09-01/": {
             "source": "tos_L1_1920x1080@29.97_30 version 4 (2023-02-13)",
@@ -1173,8 +1173,8 @@
             "hasSEI": false,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t10/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t10/2023-09-01/t10.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t10/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t10/2023-09-01/t10.zip"
         },
         "cfhd_sets/14.985_29.97_59.94/t11/2023-09-01/": {
             "source": "tos_L1_1920x1080@29.97_30 version 4 (2023-02-13)",
@@ -1191,8 +1191,8 @@
             "hasSEI": true,
             "hasVUITiming": true,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t11/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t11/2023-09-01/t11.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t11/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t11/2023-09-01/t11.zip"
         },
         "cfhd_sets/14.985_29.97_59.94/t12/2023-09-01/": {
             "source": "tos_L1_1920x1080@29.97_30 version 4 (2023-02-13)",
@@ -1209,8 +1209,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc3",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t12/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t12/2023-09-01/t12.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t12/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t12/2023-09-01/t12.zip"
         },
         "cfhd_sets/14.985_29.97_59.94/t13/2023-09-01/": {
             "source": "tos_L1_1920x1080@29.97_30 version 4 (2023-02-13)",
@@ -1227,8 +1227,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1+3",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t13/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t13/2023-09-01/t13.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t13/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t13/2023-09-01/t13.zip"
         },
         "cfhd_sets/14.985_29.97_59.94/t14/2023-09-01/": {
             "source": "tos_L1_1920x1080@29.97_30 version 4 (2023-02-13)",
@@ -1245,8 +1245,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t14/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t14/2023-09-01/t14.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t14/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t14/2023-09-01/t14.zip"
         },
         "cfhd_sets/14.985_29.97_59.94/t15/2023-09-01/": {
             "source": "tos_L1_1920x1080@29.97_30 version 4 (2023-02-13)",
@@ -1263,8 +1263,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t15/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t15/2023-09-01/t15.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t15/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t15/2023-09-01/t15.zip"
         },
         "cfhd_sets/14.985_29.97_59.94/t16/2023-09-01/": {
             "source": "tos_L1_1920x1080@29.97_30 version 4 (2023-02-13)",
@@ -1281,8 +1281,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t16/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t16/2023-09-01/t16.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t16/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t16/2023-09-01/t16.zip"
         },
         "cfhd_sets/14.985_29.97_59.94/t17/2023-09-01/": {
             "source": "tos_L1_1920x1080@29.97_30 version 4 (2023-02-13)",
@@ -1299,8 +1299,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t17/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t17/2023-09-01/t17.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t17/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t17/2023-09-01/t17.zip"
         },
         "cfhd_sets/14.985_29.97_59.94/t19/2023-09-01/": {
             "source": "tos_L1_1920x1080@29.97_60 version 4 (2023-02-13)",
@@ -1317,8 +1317,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t19/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t19/2023-09-01/t19.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t19/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t19/2023-09-01/t19.zip"
         },
         "cfhd_sets/14.985_29.97_59.94/t21/2023-09-01/": {
             "source": "tos_K1_1600x900@29.97_60 version 4 (2023-02-13)",
@@ -1335,8 +1335,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t21/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t21/2023-09-01/t21.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t21/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t21/2023-09-01/t21.zip"
         },
         "cfhd_sets/14.985_29.97_59.94/t22/2023-09-01/": {
             "source": "tos_J1_1280x720@29.97_60 version 4 (2023-02-13)",
@@ -1353,8 +1353,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t22/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t22/2023-09-01/t22.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t22/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t22/2023-09-01/t22.zip"
         },
         "cfhd_sets/14.985_29.97_59.94/t23/2023-09-01/": {
             "source": "tos_J1_1280x720@59.94_60 version 4 (2023-02-13)",
@@ -1371,8 +1371,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t23/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t23/2023-09-01/t23.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t23/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t23/2023-09-01/t23.zip"
         },
         "cfhd_sets/14.985_29.97_59.94/t24/2023-09-01/": {
             "source": "tos_I1_1024x576@29.97_60 version 4 (2023-02-13)",
@@ -1389,8 +1389,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t24/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t24/2023-09-01/t24.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t24/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t24/2023-09-01/t24.zip"
         },
         "cfhd_sets/14.985_29.97_59.94/t25/2023-09-01/": {
             "source": "tos_I2_1024x576@29.97_60 version 4 (2023-02-13)",
@@ -1407,8 +1407,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t25/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t25/2023-09-01/t25.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t25/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t25/2023-09-01/t25.zip"
         },
         "cfhd_sets/14.985_29.97_59.94/t26/2023-09-01/": {
             "source": "tos_H1_960x540@29.97_60 version 4 (2023-02-13)",
@@ -1425,8 +1425,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t26/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t26/2023-09-01/t26.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t26/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t26/2023-09-01/t26.zip"
         },
         "cfhd_sets/14.985_29.97_59.94/t27/2023-09-01/": {
             "source": "tos_G1_852x480@29.97_60 version 4 (2023-02-13)",
@@ -1443,8 +1443,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t27/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t27/2023-09-01/t27.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t27/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t27/2023-09-01/t27.zip"
         },
         "cfhd_sets/14.985_29.97_59.94/t28/2023-09-01/": {
             "source": "tos_F1_768x432@29.97_60 version 4 (2023-02-13)",
@@ -1461,8 +1461,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t28/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t28/2023-09-01/t28.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t28/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t28/2023-09-01/t28.zip"
         },
         "cfhd_sets/14.985_29.97_59.94/t29/2023-09-01/": {
             "source": "tos_E1_720x404@29.97_60 version 4 (2023-02-13)",
@@ -1479,8 +1479,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t29/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t29/2023-09-01/t29.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t29/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t29/2023-09-01/t29.zip"
         },
         "cfhd_sets/14.985_29.97_59.94/t30/2023-09-01/": {
             "source": "tos_D1_704x396@29.97_60 version 4 (2023-02-13)",
@@ -1497,8 +1497,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t30/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t30/2023-09-01/t30.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t30/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t30/2023-09-01/t30.zip"
         },
         "cfhd_sets/14.985_29.97_59.94/t31/2023-09-01/": {
             "source": "tos_C1_640x360@29.97_60 version 4 (2023-02-13)",
@@ -1515,8 +1515,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t31/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t31/2023-09-01/t31.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t31/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t31/2023-09-01/t31.zip"
         },
         "cfhd_sets/14.985_29.97_59.94/t32/2023-09-01/": {
             "source": "tos_B1_512x288@29.97_60 version 4 (2023-02-13)",
@@ -1533,8 +1533,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t32/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t32/2023-09-01/t32.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t32/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t32/2023-09-01/t32.zip"
         },
         "cfhd_sets/14.985_29.97_59.94/t33/2023-09-01/": {
             "source": "tos_A1_480x270@29.97_60 version 4 (2023-02-13)",
@@ -1551,8 +1551,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t33/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t33/2023-09-01/t33.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t33/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t33/2023-09-01/t33.zip"
         },
         "cfhd_sets/14.985_29.97_59.94/t34/2023-09-01/": {
             "source": "tos_A1_480x270@14.985_60 version 4 (2023-02-13)",
@@ -1569,8 +1569,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t34/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t34/2023-09-01/t34.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t34/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t34/2023-09-01/t34.zip"
         },
         "switching_sets/14.985_29.97_59.94/ss1/2023-10-05": {
             "source": "CTA WAVE",
@@ -1635,8 +1635,8 @@
             "hasSEI": false,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/switching_sets/14.985_29.97_59.94/ss1/2023-10-05/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/switching_sets/14.985_29.97_59.94/ss1/2023-10-05/ss1.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/switching_sets/14.985_29.97_59.94/ss1/2023-10-05/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/switching_sets/14.985_29.97_59.94/ss1/2023-10-05/ss1.zip"
         }
     },
     "CHDF": {
@@ -1655,8 +1655,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/chdf_sets/12.5_25_50/t20/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/chdf_sets/12.5_25_50/t20/2023-09-01/t20.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/chdf_sets/12.5_25_50/t20/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/chdf_sets/12.5_25_50/t20/2023-09-01/t20.zip"
         },
         "chdf_sets/15_30_60/t20/2023-09-01/": {
             "source": "tos_L2_1920x1080@60_60 version 4 (2023-02-13)",
@@ -1673,8 +1673,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/chdf_sets/15_30_60/t20/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/chdf_sets/15_30_60/t20/2023-09-01/t20.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/chdf_sets/15_30_60/t20/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/chdf_sets/15_30_60/t20/2023-09-01/t20.zip"
         },
         "chdf_sets/14.985_29.97_59.94/t20/2023-09-01/": {
             "source": "tos_L2_1920x1080@59.94_60 version 4 (2023-02-13)",
@@ -1691,8 +1691,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/chdf_sets/14.985_29.97_59.94/t20/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/chdf_sets/14.985_29.97_59.94/t20/2023-09-01/t20.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/chdf_sets/14.985_29.97_59.94/t20/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/chdf_sets/14.985_29.97_59.94/t20/2023-09-01/t20.zip"
         }
     },
     "CHH1": {
@@ -1711,8 +1711,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "hvc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/chh1_sets/12.5_25_50/t1/2023-05-12/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/chh1_sets/12.5_25_50/t1/2023-05-12/t1.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/chh1_sets/12.5_25_50/t1/2023-05-12/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/chh1_sets/12.5_25_50/t1/2023-05-12/t1.zip"
         },
         "chh1_sets/15_30_60/t1/2023-05-12/": {
             "source": "tos_L1_1920x1080@30_30 version 4 (2023-02-13)",
@@ -1729,8 +1729,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "hvc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/chh1_sets/15_30_60/t1/2023-05-12/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/chh1_sets/15_30_60/t1/2023-05-12/t1.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/chh1_sets/15_30_60/t1/2023-05-12/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/chh1_sets/15_30_60/t1/2023-05-12/t1.zip"
         },
         "chh1_sets/14.985_29.97_59.94/t1/2023-05-12/": {
             "source": "tos_L1_1920x1080@29.97_30 version 4 (2023-02-13)",
@@ -1747,8 +1747,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "hvc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/chh1_sets/14.985_29.97_59.94/t1/2023-05-12/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/chh1_sets/14.985_29.97_59.94/t1/2023-05-12/t1.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/chh1_sets/14.985_29.97_59.94/t1/2023-05-12/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/chh1_sets/14.985_29.97_59.94/t1/2023-05-12/t1.zip"
         }
     },
     "CENC": {
@@ -1767,8 +1767,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t1-cenc/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t1-cenc/2023-09-01/t1-cenc.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t1-cenc/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/t1-cenc/2023-09-01/t1-cenc.zip"
         },
         "cfhd_sets/15_30_60/t1-cenc/2023-09-01/": {
             "source": "tos_L1_1920x1080@30_30 version 4 (2023-02-13)",
@@ -1785,8 +1785,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t1-cenc/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t1-cenc/2023-09-01/t1-cenc.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t1-cenc/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/15_30_60/t1-cenc/2023-09-01/t1-cenc.zip"
         },
         "cfhd_sets/14.985_29.97_59.94/t1-cenc/2023-09-01/": {
             "source": "tos_L1_1920x1080@29.97_30 version 4 (2023-02-13)",
@@ -1803,8 +1803,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t1-cenc/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t1-cenc/2023-09-01/t1-cenc.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t1-cenc/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/14.985_29.97_59.94/t1-cenc/2023-09-01/t1-cenc.zip"
         }
     },
     "CFHD-SPLICING": {
@@ -1823,8 +1823,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/splice_main/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/splice_main/2023-09-01/splice_main.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/splice_main/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/splice_main/2023-09-01/splice_main.zip"
         },
         "cfhd_sets/12.5_25_50/splice_main-cenc/2023-09-01/": {
             "source": "CTA WAVE - splice_main_croatia_A1_1280x720@25_10 version 4",
@@ -1841,8 +1841,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/splice_main-cenc/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/splice_main-cenc/2023-09-01/splice_main-cenc.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/splice_main-cenc/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/splice_main-cenc/2023-09-01/splice_main-cenc.zip"
         },
         "cfhd_sets/12.5_25_50/splice_ad/2023-09-01/": {
             "source": "CTA WAVE - splice_ad_bbb_AD-A1_1280x720@25_5.76 version 4",
@@ -1859,8 +1859,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/splice_ad/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/splice_ad/2023-09-01/splice_ad.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/splice_ad/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/splice_ad/2023-09-01/splice_ad.zip"
         },
         "cfhd_sets/12.5_25_50/splice_ad-cenc/2023-09-01/": {
             "source": "CTA WAVE - splice_ad_bbb_AD-A1_1280x720@25_5.76 version 4",
@@ -1877,8 +1877,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/splice_ad-cenc/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/splice_ad-cenc/2023-09-01/splice_ad-cenc.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/splice_ad-cenc/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/splice_ad-cenc/2023-09-01/splice_ad-cenc.zip"
         }
     },
     "CEAC": {
@@ -1893,8 +1893,8 @@
             "channel": "stereo",
             "segmentDuration": "2.016",
             "chunksPerFragment": "1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/releases/1/ceac_sets/eac3/at1/2023-11-08/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/releases/1/ceac_sets/eac3/at1/2023-11-08/at1.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/releases/1/ceac_sets/eac3/at1/2023-11-08/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/releases/1/ceac_sets/eac3/at1/2023-11-08/at1.zip"
         },
         "ceac_sets/eac3/at2/2023-11-08/": {
             "representations": [
@@ -1907,8 +1907,8 @@
             "channel": "stereo",
             "segmentDuration": "2.016",
             "chunksPerFragment": "4",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/releases/1/ceac_sets/eac3/at2/2023-11-08/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/releases/1/ceac_sets/eac3/at2/2023-11-08/at2.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/releases/1/ceac_sets/eac3/at2/2023-11-08/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/releases/1/ceac_sets/eac3/at2/2023-11-08/at2.zip"
         },
         "ceac_sets/eac3/at3/2023-11-08/": {
             "representations": [
@@ -1921,8 +1921,8 @@
             "channel": "stereo",
             "segmentDuration": "2.016",
             "chunksPerFragment": "1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/releases/1/ceac_sets/eac3/at3/2023-11-08/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/releases/1/ceac_sets/eac3/at3/2023-11-08/at3.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/releases/1/ceac_sets/eac3/at3/2023-11-08/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/releases/1/ceac_sets/eac3/at3/2023-11-08/at3.zip"
         },
 	"ceac_sets/eac3/at4/2023-11-08/": {
             "representations": [
@@ -1935,8 +1935,8 @@
             "channel": "stereo",
             "segmentDuration": "2.016",
             "chunksPerFragment": "1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/releases/1/ceac_sets/eac3/at4/2023-11-08/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/releases/1/ceac_sets/eac3/at4/2023-11-08/at4.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/releases/1/ceac_sets/eac3/at4/2023-11-08/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/releases/1/ceac_sets/eac3/at4/2023-11-08/at4.zip"
         }
     },
     "CA4S": {
@@ -1952,8 +1952,8 @@
             "channel": "stereo",
             "segmentDuration": "2.0",
             "chunksPerFragment": "1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/releases/1/ca4s_sets/ac4/at1/2023-08-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/releases/1/ca4s_sets/ac4/at1/2023-08-01/at1.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/releases/1/ca4s_sets/ac4/at1/2023-08-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/releases/1/ca4s_sets/ac4/at1/2023-08-01/at1.zip"
         },
         "ca4s_sets/ac4/at2/2023-08-01/": {
             "representations": [
@@ -1967,8 +1967,8 @@
             "channel": "stereo",
             "segmentDuration": "2.0",
             "chunksPerFragment": "4",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/releases/1/ca4s_sets/ac4/at2/2023-08-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/releases/1/ca4s_sets/ac4/at2/2023-08-01/at2.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/releases/1/ca4s_sets/ac4/at2/2023-08-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/releases/1/ca4s_sets/ac4/at2/2023-08-01/at2.zip"
         },
         "ca4s_sets/ac4/at3/2023-08-01/": {
             "representations": [
@@ -1982,8 +1982,8 @@
             "channel": "stereo",
             "segmentDuration": "2.0",
             "chunksPerFragment": "1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/releases/1/ca4s_sets/ac4/at3/2023-08-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/releases/1/ca4s_sets/ac4/at3/2023-08-01/at3.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/releases/1/ca4s_sets/ac4/at3/2023-08-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/releases/1/ca4s_sets/ac4/at3/2023-08-01/at3.zip"
         },
 	"ca4s_sets/ac4/at4/2023-08-01/": {
             "representations": [
@@ -1997,8 +1997,8 @@
             "channel": "stereo",
             "segmentDuration": "2.0",
             "chunksPerFragment": "1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/releases/1/ca4s_sets/ac4/at4/2023-08-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/releases/1/ca4s_sets/ac4/at4/2023-08-01/at4.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/releases/1/ca4s_sets/ac4/at4/2023-08-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/releases/1/ca4s_sets/ac4/at4/2023-08-01/at4.zip"
         }
     },
     "CAAC": {
@@ -2013,8 +2013,8 @@
             "chunksPerFragment": "1",
             "trunVersion": "v0",
             "editList": "With",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/releases/1/caac_sets/aac_lc/at1/2023-04-27/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/releases/1/caac_sets/aac_lc/at1/2023-04-27/at1.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/releases/1/caac_sets/aac_lc/at1/2023-04-27/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/releases/1/caac_sets/aac_lc/at1/2023-04-27/at1.zip"
         },
 	"caac_sets/aac_lc/at2/2023-08-01/": {
             "representations": {
@@ -2027,8 +2027,8 @@
             "chunksPerFragment": "4",
             "trunVersion": "v0",
             "editList": "With",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/releases/1/caac_sets/aac_lc/at2/2023-08-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/releases/1/caac_sets/aac_lc/at2/2023-08-01/at2.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/releases/1/caac_sets/aac_lc/at2/2023-08-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/releases/1/caac_sets/aac_lc/at2/2023-08-01/at2.zip"
         },
         "caac_sets/aac_lc/at3/2023-04-27/": {
             "representations": {
@@ -2041,8 +2041,8 @@
             "chunksPerFragment": "1",
             "trunVersion": "v1",
             "editList": "With",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/releases/1/caac_sets/aac_lc/at3/2023-04-27/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/releases/1/caac_sets/aac_lc/at3/2023-04-27/at3.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/releases/1/caac_sets/aac_lc/at3/2023-04-27/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/releases/1/caac_sets/aac_lc/at3/2023-04-27/at3.zip"
         },
         "caac_sets/aac_lc/at4/2023-04-27/": {
             "representations": {
@@ -2055,8 +2055,8 @@
             "chunksPerFragment": "1",
             "trunVersion": "v1",
             "editList": "Without",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/releases/1/caac_sets/aac_lc/at4/2023-04-27/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/releases/1/caac_sets/aac_lc/at4/2023-04-27/at4.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/releases/1/caac_sets/aac_lc/at4/2023-04-27/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/releases/1/caac_sets/aac_lc/at4/2023-04-27/at4.zip"
         },
         "caac_sets/aac_lc/at5/2023-04-27/": {
             "representations": {
@@ -2069,8 +2069,8 @@
             "chunksPerFragment": "1",
             "trunVersion": "v0",
             "editList": "With",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/releases/1/caac_sets/aac_lc/at5/2023-04-27/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/releases/1/caac_sets/aac_lc/at5/2023-04-27/at5.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/releases/1/caac_sets/aac_lc/at5/2023-04-27/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/releases/1/caac_sets/aac_lc/at5/2023-04-27/at5.zip"
         },
         "caac_sets/aac_lc/at13/2023-04-27/": {
             "representations": {
@@ -2083,8 +2083,8 @@
             "chunksPerFragment": "1",
             "trunVersion": "v0",
             "editList": "With",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/releases/1/caac_sets/aac_lc/at13/2023-04-27/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/releases/1/caac_sets/aac_lc/at13/2023-04-27/at13.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/releases/1/caac_sets/aac_lc/at13/2023-04-27/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/releases/1/caac_sets/aac_lc/at13/2023-04-27/at13.zip"
         },
 	"caac_sets/aac_lc/at14/2023-04-27/": {
             "representations": {
@@ -2097,8 +2097,8 @@
             "chunksPerFragment": "1",
             "trunVersion": "v0",
             "editList": "With",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/releases/1/caac_sets/aac_lc/at14/2023-04-27/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/releases/1/caac_sets/aac_lc/at14/2023-04-27/at14.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/releases/1/caac_sets/aac_lc/at14/2023-04-27/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/releases/1/caac_sets/aac_lc/at14/2023-04-27/at14.zip"
         },
 	"caac_sets/aac_lc/at15/2023-08-01/": {
             "representations": {
@@ -2111,8 +2111,8 @@
             "chunksPerFragment": "1",
             "trunVersion": "v0",
             "editList": "With",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/releases/1/caac_sets/aac_lc/at15/2023-08-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/releases/1/caac_sets/aac_lc/at15/2023-08-01/at15.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/releases/1/caac_sets/aac_lc/at15/2023-08-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/releases/1/caac_sets/aac_lc/at15/2023-08-01/at15.zip"
         },
 	"caac_sets/aac_lc/at16/2023-08-01/": {
             "representations": {
@@ -2125,8 +2125,8 @@
             "chunksPerFragment": "1",
             "trunVersion": "v0",
             "editList": "With",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/releases/1/caac_sets/aac_lc/at16/2023-08-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/releases/1/caac_sets/aac_lc/at16/2023-08-01/at16.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/releases/1/caac_sets/aac_lc/at16/2023-08-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/releases/1/caac_sets/aac_lc/at16/2023-08-01/at16.zip"
 	},
         "caac_sets/he_aac/at6/2023-04-27/": {
             "representations": {
@@ -2139,8 +2139,8 @@
             "chunksPerFragment": "1",
             "trunVersion": "v0",
             "editList": "With",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/releases/1/caac_sets/he_aac/at6/2023-04-27/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/releases/1/caac_sets/he_aac/at6/2023-04-27/at6.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/releases/1/caac_sets/he_aac/at6/2023-04-27/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/releases/1/caac_sets/he_aac/at6/2023-04-27/at6.zip"
         },
         "caac_sets/he_aac_v2/at7/2023-04-27/": {
             "representations": {
@@ -2153,8 +2153,8 @@
             "chunksPerFragment": "1",
             "trunVersion": "v0",
             "editList": "With",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/releases/1/caac_sets/he_aac_v2/at7/2023-04-27/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/releases/1/caac_sets/he_aac_v2/at7/2023-04-27/at7.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/releases/1/caac_sets/he_aac_v2/at7/2023-04-27/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/releases/1/caac_sets/he_aac_v2/at7/2023-04-27/at7.zip"
         }
     },
     "CAAA": {
@@ -2169,8 +2169,8 @@
             "chunksPerFragment": "1",
             "trunVersion": "v0",
             "editList": "With",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/releases/1/caaa_sets/aac_lc/at8/2023-04-27/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/releases/1/caaa_sets/aac_lc/at8/2023-04-27/at8.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/releases/1/caaa_sets/aac_lc/at8/2023-04-27/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/releases/1/caaa_sets/aac_lc/at8/2023-04-27/at8.zip"
         },
         "caaa_sets/he_aac/at9/2023-04-27/": {
             "representations": {
@@ -2183,8 +2183,8 @@
             "chunksPerFragment": "1",
             "trunVersion": "v0",
             "editList": "With",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/releases/1/caaa_sets/he_aac/at9/2023-04-27/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/releases/1/caaa_sets/he_aac/at9/2023-04-27/at9.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/releases/1/caaa_sets/he_aac/at9/2023-04-27/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/releases/1/caaa_sets/he_aac/at9/2023-04-27/at9.zip"
         },
         "caaa_sets/he_aac_v2/at10/2023-04-27/": {
             "representations": {
@@ -2197,8 +2197,8 @@
             "chunksPerFragment": "1",
             "trunVersion": "v0",
             "editList": "With",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/releases/1/caaa_sets/he_aac_v2/at10/2023-04-27/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/releases/1/caaa_sets/he_aac_v2/at10/2023-04-27/at10.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/releases/1/caaa_sets/he_aac_v2/at10/2023-04-27/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/releases/1/caaa_sets/he_aac_v2/at10/2023-04-27/at10.zip"
         }
     },
     "CAMC": {
@@ -2213,8 +2213,8 @@
             "chunksPerFragment": "1",
             "trunVersion": "v0",
             "editList": "With",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/releases/1/camc_sets/aac_lc/at11/2023-04-27/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/releases/1/camc_sets/aac_lc/at11/2023-04-27/at11.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/releases/1/camc_sets/aac_lc/at11/2023-04-27/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/releases/1/camc_sets/aac_lc/at11/2023-04-27/at11.zip"
         },
         "camc_sets/he_aac/at12/2023-04-27/": {
             "representations": {
@@ -2227,8 +2227,8 @@
             "chunksPerFragment": "1",
             "trunVersion": "v0",
             "editList": "With",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/releases/1/camc_sets/he_aac/at12/2023-04-27/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/releases/1/camc_sets/he_aac/at12/2023-04-27/at12.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/releases/1/camc_sets/he_aac/at12/2023-04-27/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/releases/1/camc_sets/he_aac/at12/2023-04-27/at12.zip"
         }
     },
     "DTS1": {
@@ -2243,8 +2243,8 @@
             "chunksPerFragment": "1",
             "trunVersion": "v0",
             "editList": "With",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/dts1_sets/dtsc/at1/2023-06-26/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/dts1_sets/dtsc/at1/2023-06-26/at1.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/dts1_sets/dtsc/at1/2023-06-26/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/dts1_sets/dtsc/at1/2023-06-26/at1.zip"
         },
         "dts1_sets/dtsc/at1-cenc/2023-06-26/": {
             "representations": {
@@ -2257,8 +2257,8 @@
             "chunksPerFragment": "1",
             "trunVersion": "v0",
             "editList": "With",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/dts1_sets/dtsc/at1-cenc/2023-06-26/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/dts1_sets/dtsc/at1-cenc/2023-06-26/at1-cenc.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/dts1_sets/dtsc/at1-cenc/2023-06-26/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/dts1_sets/dtsc/at1-cenc/2023-06-26/at1-cenc.zip"
         },
         "dts1_sets/dtsc/at2/2023-06-26/": {
             "representations": {
@@ -2271,8 +2271,8 @@
             "chunksPerFragment": "4",
             "trunVersion": "v0",
             "editList": "With",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/dts1_sets/dtsc/at2/2023-06-26/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/dts1_sets/dtsc/at2/2023-06-26/at2.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/dts1_sets/dtsc/at2/2023-06-26/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/dts1_sets/dtsc/at2/2023-06-26/at2.zip"
         },
         "dts1_sets/dtse/at1/2023-06-26/": {
             "representations": {
@@ -2285,8 +2285,8 @@
             "chunksPerFragment": "1",
             "trunVersion": "v0",
             "editList": "With",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/dts1_sets/dtse/at1/2023-06-26/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/dts1_sets/dtse/at1/2023-06-26/at1.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/dts1_sets/dtse/at1/2023-06-26/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/dts1_sets/dtse/at1/2023-06-26/at1.zip"
         },
         "dts1_sets/dtse/at1-cenc/2023-06-26/": {
             "representations": {
@@ -2299,8 +2299,8 @@
             "chunksPerFragment": "1",
             "trunVersion": "v0",
             "editList": "With",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/dts1_sets/dtse/at1-cenc/2023-06-26/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/dts1_sets/dtse/at1-cenc/2023-06-26/at1-cenc.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/dts1_sets/dtse/at1-cenc/2023-06-26/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/dts1_sets/dtse/at1-cenc/2023-06-26/at1-cenc.zip"
         },
         "dts1_sets/dtse/at2/2023-06-26/": {
             "representations": {
@@ -2313,8 +2313,8 @@
             "chunksPerFragment": "4",
             "trunVersion": "v0",
             "editList": "With",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/dts1_sets/dtse/at2/2023-06-26/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/dts1_sets/dtse/at2/2023-06-26/at2.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/dts1_sets/dtse/at2/2023-06-26/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/dts1_sets/dtse/at2/2023-06-26/at2.zip"
         }
     },
     "chunked": {
@@ -2333,8 +2333,8 @@
             "hasSEI": true,
             "hasVUITiming": false,
             "visualSampleEntry": "avc1",
-            "mpdPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/chunked/2023-09-01/stream.mpd",
-            "zipPath": "https://dash.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/chunked/2023-09-01/chunked.zip"
+            "mpdPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/chunked/2023-09-01/stream.mpd",
+            "zipPath": "https://dash-large-files.akamaized.net/WAVE/vectors/cfhd_sets/12.5_25_50/chunked/2023-09-01/chunked.zip"
         }
     }
 }

--- a/scripts/test_db_links.py
+++ b/scripts/test_db_links.py
@@ -1,0 +1,44 @@
+import json
+import requests
+from tqdm import tqdm
+import sys
+import argparse
+
+def main(database):
+    
+    with open(database, 'rb') as fo:
+        data = json.load(fo)
+
+    batch = []
+    errors = []
+    
+    for _, store in data.items():
+        for test, vector in store.items():
+            batch.append((test, vector))
+    
+    # NOTE: the script checks that the links are valid,
+    # it doesn't check the integrity of the assets linked.
+    for test, vector in tqdm(batch):
+        try:
+            mpdPath = vector["mpdPath"]
+            assert test in mpdPath, f'unexpected path {mpdPath}'
+            res = requests.head(mpdPath)
+            assert res.status_code == 200, f'unexpected status {res.status_code} when checking {mpdPath}'
+
+            zipPath = vector["zipPath"]
+            assert test in zipPath, f'unexpected path {zipPath}'
+            res = requests.head(zipPath)
+            assert res.status_code == 200, f'unexpected status {res.status_code} when checking {zipPath}'
+        
+        except BaseException as e:
+            errors.append(e)
+            
+    if len(errors) > 0:
+        print(errors)
+        sys.exit(1)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("database")
+    args = parser.parse_args()
+    main(args.database)


### PR DESCRIPTION
Fixes #50 

Replaces `dash.akamaized.net` with `dash-large-files.akamaized.net` so that both small and large files can be downloaded.

Adds a script to check that links in database are all valid. The script only checks that there is a ressource at the given URL, it doesn't check asset integrity.